### PR TITLE
Use const enum for UrlType

### DIFF
--- a/src/resolve-uri.ts
+++ b/src/resolve-uri.ts
@@ -35,7 +35,7 @@ type Url = {
   type: UrlType;
 };
 
-enum UrlType {
+const enum UrlType {
   Empty = 1,
   Hash = 2,
   Query = 3,


### PR DESCRIPTION
This PR changes `UrlType` type to `const enum` from `enum`.

This change makes this package

- `UrlType` tree-shake friendly
  - TypeScript `enum` cannot be tree-shaked but `const enum` can be
- smaller
  - The file size with terser is reduced by ~18% (before: 2303B, after: 1891B)
